### PR TITLE
Added the ability to get a badge for a specific job

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ https://travis-matrix-badges.herokuapp.com/repos/${repo_owner}/${repo_name}/bran
 ```
 
 Live example:
+
 | Build1            | Build2            | Build3            | Build4            |
 |-------------------|-------------------|-------------------|-------------------|
 | [![Build1][1]][5] | [![Build2][2]][5] | [![Build3][3]][5] | [![Build4][4]][5] |

--- a/README.md
+++ b/README.md
@@ -21,5 +21,20 @@ https://travis-matrix-badges.herokuapp.com/repos/${repo_owner}/${repo_name}/bran
 
 [![Build Status](https://travis-matrix-badges.herokuapp.com/repos/bjfish/grails-ci-build-matrix-example/branches/master)](https://travis-ci.org/bjfish/grails-ci-build-matrix-example)
 
+### Badge-Per-Job
 
+Another option would be to specify a badge per job:
+```
+https://travis-matrix-badges.herokuapp.com/repos/${repo_owner}/${repo_name}/branches/${branch}/${job_number}
+```
 
+Live example:
+| Build1            | Build2            | Build3            | Build4            |
+|-------------------|-------------------|-------------------|-------------------|
+| [![Build1][1]][5] | [![Build2][2]][5] | [![Build3][3]][5] | [![Build4][4]][5] |
+
+[1]: https://travis-matrix-badges.herokuapp.com/repos/bjfish/grails-ci-build-matrix-example/branches/master/1
+[2]: https://travis-matrix-badges.herokuapp.com/repos/bjfish/grails-ci-build-matrix-example/branches/master/2
+[3]: https://travis-matrix-badges.herokuapp.com/repos/bjfish/grails-ci-build-matrix-example/branches/master/3
+[4]: https://travis-matrix-badges.herokuapp.com/repos/bjfish/grails-ci-build-matrix-example/branches/master/4
+[5]: https://travis-ci.org/bjfish/grails-ci-build-matrix-example


### PR DESCRIPTION
This will allow getting a badge for a specific job (with similar style to the travis badge), and will give better control over how the markdown is rendered.
The format is similar to the original request, only with the job index at the end (https://travis-matrix-badges.herokuapp.com/repos/${repo_owner}/${repo_name}/branches/${branch}/${job_index}).
The job index is the index of the job in the list of jobs in the matrix.
For example (from your readme): https://travis-matrix-badges.herokuapp.com/repos/bjfish/grails-ci-build-matrix-example/branches/master/1
This will give a "passed" badge as the first build is currently passing.
The original format will still work and the result will look the same.
Resolves #1  